### PR TITLE
change noSemi to semi

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,5 +14,5 @@ module.exports = {
   singleQuote: true,
   trailingComma: 'none',
   jsxBracketSameLine: false,
-  noSemi: false
+  semi: true
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-guestline",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Prettier configuration used by Guestline",
   "repository": "guestlinelabs/prettier-config-guestline",
   "license": "MIT",


### PR DESCRIPTION
`noSemi` is not an option recognized by the CLI, so I'm changing it to [semi](https://prettier.io/docs/en/options.html#semicolons).