### PR TITLE
Updated Prettier to 2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-guestline",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Prettier configuration used by Guestline",
   "repository": "guestlinelabs/prettier-config-guestline",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
   "bugs": {
     "url": "https://github.com/guestlinelabs/prettier-config-guestline/issues"
   },
-  "files": ["index.js"],
+  "files": [
+    "index.js"
+  ],
   "devDependencies": {
-    "prettier": "^1.11.1"
+    "prettier": "^2.3.2"
   },
   "peerDependencies": {
-    "prettier": "^1.11.1"
+    "prettier": "^2.3.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,7 @@
 # yarn lockfile v1
 
 
-prettier@^1.11.1:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.11.1.tgz#61e43fc4cd44e68f2b0dfc2c38cd4bb0fccdcc75"
+"prettier@^2.3.2":
+  "integrity" "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ=="
+  "resolved" "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz"
+  "version" "2.3.2"


### PR DESCRIPTION
Since Prettier jumped to v2 a year ago, I think it's about time we use it :)

Also if you try to use it in a project without updating this, then you'll end with conflicts and a poorly NPM

![image](https://user-images.githubusercontent.com/5593892/132218504-8b2b9b95-1a33-4016-aa82-73a4c5924b6e.png)
